### PR TITLE
fix: readme bots wrong url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 ## Bots
 
-- [Koto](https://github.com/yugen-bot/yugen/tree/main/apps/koto) - A collaborative wordle bot
-- [Kusari](https://github.com/yugen-bot/yugen/tree/main/apps/kusari) - A collaborative word chain bot
-- [Kazu](https://github.com/yugen-bot/yugen/tree/main/apps/kazu) - A collaborative counting bot
-- [Hoshi](https://github.com/yugen-bot/yugen/tree/main/apps/hoshi) - A starboard bot with ability for multiple starboards
-- [Iro](https://github.com/yugen-bot/yugen/tree/main/apps/iro) - A bot that replies with colors on recognized color codes
+- [Koto](https://github.com/yugen-bot/bots/tree/main/apps/koto) - A collaborative wordle bot
+- [Kusari](https://github.com/yugen-bot/bots/tree/main/apps/kusari) - A collaborative word chain bot
+- [Kazu](https://github.com/yugen-bot/bots/tree/main/apps/kazu) - A collaborative counting bot
+- [Hoshi](https://github.com/yugen-bot/bots/tree/main/apps/hoshi) - A starboard bot with ability for multiple starboards
+- [Iro](https://github.com/yugen-bot/bots/tree/main/apps/iro) - A bot that replies with colors on recognized color codes
 
 **Built with [disgo](https://github.com/disgoorg/disgo)**
 


### PR DESCRIPTION
```diff
-- [Koto](https://github.com/yugen-bot/yugen/tree/main/apps/koto) - A collaborative wordle bot
-- [Kusari](https://github.com/yugen-bot/yugen/tree/main/apps/kusari) - A collaborative word chain bot
-- [Kazu](https://github.com/yugen-bot/yugen/tree/main/apps/kazu) - A collaborative counting bot
-- [Hoshi](https://github.com/yugen-bot/yugen/tree/main/apps/hoshi) - A starboard bot with ability for multiple starboards
-- [Iro](https://github.com/yugen-bot/yugen/tree/main/apps/iro) - A bot that replies with colors on recognized color codes
+- [Koto](https://github.com/yugen-bot/bots/tree/main/apps/koto) - A collaborative wordle bot
+- [Kusari](https://github.com/yugen-bot/bots/tree/main/apps/kusari) - A collaborative word chain bot
+- [Kazu](https://github.com/yugen-bot/bots/tree/main/apps/kazu) - A collaborative counting bot
+- [Hoshi](https://github.com/yugen-bot/bots/tree/main/apps/hoshi) - A starboard bot with ability for multiple starboards
+- [Iro](https://github.com/yugen-bot/bots/tree/main/apps/iro) - A bot that replies with colors on recognized color codes
```